### PR TITLE
download-eplus-video.md: add the missing parameter "driver" for "download_ts()"

### DIFF
--- a/source/_posts/download-eplus-video.md
+++ b/source/_posts/download-eplus-video.md
@@ -85,7 +85,7 @@ def main():
 
     downloading = 0
     for path in tqdm(ts_paths):
-        if download_ts(path):
+        if download_ts(driver, path):
             downloading += 1
         if downloading == 10:
             sleep(60)


### PR DESCRIPTION
Here is a comment of the post *[使用selenium下载eplus直播存档视频](https://michiyamakaren.github.io/2021/08/05/download-eplus-video/#619c1c2a00c6e664e5cb79ac)*:

> <div class="vcard" id="619c1c2a00c6e664e5cb79ac"><img class="vimg" src="https://gravatar.loli.net/avatar/e88b1ca06bfb0bc4189e0ca4e07579dd?d=identicon&amp;v=1.5.1"><div class="vh"><div class="vhead"><span class="vnick">xqwpf</span> <span class="vsys">Firefox 94.0</span> <span class="vsys">Windows 11</span></div><div class="vmeta"><span class="vtime">2021-11-23</span><span class="vat" data-vm-id="619c1c2a00c6e664e5cb79ac" data-self-id="619c1c2a00c6e664e5cb79ac">回复</span></div><div class="vcontent" data-expand="查看更多..."><p>Exception download_ts() missing 1 required positional argument: ‘ts_path’ occured, restarting…<br>怎么办啊。。。。。</p>

I fixed it.